### PR TITLE
Fix NoSuchMethodError on ChannelDeleteEvent#getChannel

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ ext {
     javaWebSocketVersion        = '1.5.1'
     slf4jVersion                = '1.7.25'
     jsonOrgVersion              = '20180130'
-    jdaVersion                  = '5.0.0-alpha.5'
+    jdaVersion                  = '5.0.0-alpha.17'
     spotbugsAnnotationsVersion  = '3.1.3'
     prometheusVersion           = '0.4.0'
 


### PR DESCRIPTION
It returns a different class, so it fails in runtime with the following error:

```
Aug 13 20:38:26 PatreonServer java[17540]: java.lang.NoSuchMethodError: 'net.dv8tion.jda.api.entities.Channel net.dv8tion.jda.api.events.channel.ChannelDeleteEvent.getChannel()'
Aug 13 20:38:26 PatreonServer java[17540]:         at lavalink.client.io.jda.JdaLavalink.onEvent(JdaLavalink.java:138)
Aug 13 20:38:26 PatreonServer java[17540]:         at net.dv8tion.jda.api.hooks.InterfacedEventManager.handle(InterfacedEventManager.java:96)
Aug 13 20:38:26 PatreonServer java[17540]:         at net.kodehawa.mantarobot.core.MantaroEventManager.handle(MantaroEventManager.java:36)
Aug 13 20:38:26 PatreonServer java[17540]:         at net.dv8tion.jda.internal.hooks.EventManagerProxy.handleInternally(EventManagerProxy.java:88)
Aug 13 20:38:26 PatreonServer java[17540]:         at net.dv8tion.jda.internal.hooks.EventManagerProxy.handle(EventManagerProxy.java:70)
Aug 13 20:38:26 PatreonServer java[17540]:         at net.dv8tion.jda.internal.JDAImpl.handleEvent(JDAImpl.java:170)
Aug 13 20:38:26 PatreonServer java[17540]:         at net.dv8tion.jda.internal.handle.ChannelDeleteHandler.handleInternally(ChannelDeleteHandler.java:102)
Aug 13 20:38:26 PatreonServer java[17540]:         at net.dv8tion.jda.internal.handle.SocketHandler.handle(SocketHandler.java:39)
Aug 13 20:38:26 PatreonServer java[17540]:         at net.dv8tion.jda.internal.requests.WebSocketClient.onDispatch(WebSocketClient.java:953)
Aug 13 20:38:26 PatreonServer java[17540]:         at net.dv8tion.jda.internal.requests.WebSocketClient.onEvent(WebSocketClient.java:840)
Aug 13 20:38:26 PatreonServer java[17540]:         at net.dv8tion.jda.internal.requests.WebSocketClient.handleEvent(WebSocketClient.java:818)
Aug 13 20:38:26 PatreonServer java[17540]:         at net.dv8tion.jda.internal.requests.WebSocketClient.onBinaryMessage(WebSocketClient.java:992)
Aug 13 20:38:26 PatreonServer java[17540]:         at com.neovisionaries.ws.client.ListenerManager.callOnBinaryMessage(ListenerManager.java:385)
Aug 13 20:38:26 PatreonServer java[17540]:         at com.neovisionaries.ws.client.ReadingThread.callOnBinaryMessage(ReadingThread.java:276)
Aug 13 20:38:26 PatreonServer java[17540]:         at com.neovisionaries.ws.client.ReadingThread.handleBinaryFrame(ReadingThread.java:996)
Aug 13 20:38:26 PatreonServer java[17540]:         at com.neovisionaries.ws.client.ReadingThread.handleFrame(ReadingThread.java:755)
Aug 13 20:38:26 PatreonServer java[17540]:         at com.neovisionaries.ws.client.ReadingThread.main(ReadingThread.java:108)
Aug 13 20:38:26 PatreonServer java[17540]:         at com.neovisionaries.ws.client.ReadingThread.runMain(ReadingThread.java:64)
Aug 13 20:38:26 PatreonServer java[17540]:         at com.neovisionaries.ws.client.WebSocketThread.run(WebSocketThread.java:45)
```

A version bump is enough to fix it.